### PR TITLE
Add a basic support for RSA sign

### DIFF
--- a/lib/alipay.rb
+++ b/lib/alipay.rb
@@ -9,5 +9,7 @@ module Alipay
     attr_accessor :pid
     attr_accessor :key
     attr_accessor :seller_email
+    attr_accessor :rsa_private_key
+    attr_accessor :rsa_alipay_public_key
   end
 end

--- a/lib/alipay/notify.rb
+++ b/lib/alipay/notify.rb
@@ -1,7 +1,7 @@
 module Alipay
   class Notify
-    def self.verify?(params)
-      if Sign.verify?(params)
+    def self.verify?(params, sign_type=Sign::MD5)
+      if Sign.verify?(params, sign_type)
         params = Utils.stringify_keys(params)
         open("https://mapi.alipay.com/gateway.do?service=notify_verify&partner=#{Alipay.pid}&notify_id=#{CGI.escape params['notify_id'].to_s}").read == 'true'
       else

--- a/lib/alipay/sign.rb
+++ b/lib/alipay/sign.rb
@@ -2,20 +2,37 @@ require 'digest/md5'
 
 module Alipay
   module Sign
-    def self.generate(params)
+    MD5 = 1
+    RSA = 2
+
+    def self.generate_params(params)
       query = params.sort.map do |key, value|
         "#{key}=#{value}"
       end.join('&')
-
-      Digest::MD5.hexdigest("#{query}#{Alipay.key}")
     end
 
-    def self.verify?(params)
+    def self.generate(params, sign_type=MD5)
+      case sign_type
+      when MD5
+        Digest::MD5.hexdigest("#{generate_params(params)}#{Alipay.key}")
+      when RSA
+        Base64.encode64(Alipay.rsa_private_key.sign(
+          "sha1", params.force_encoding("utf-8")))
+      end
+    end
+
+    def self.verify?(params, sign_type=MD5)
       params = Utils.stringify_keys(params)
       params.delete('sign_type')
       sign = params.delete('sign')
 
-      generate(params) == sign
+      case sign_type
+      when MD5
+        generate(params) == sign
+      when RSA
+        Alipay.rsa_alipay_public_key.verify(
+          "sha1", Base64.decode64(sign), generate_params(params).force_encoding("utf-8"))
+      end
     end
   end
 end


### PR DESCRIPTION
移动支付相关的都默认是使用RSA或者DSA签名的，这个已经在生产环境使用了，不过可能还是需要补一下基本的Test
