### PR TITLE
Fix wap verify

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,13 +124,29 @@ Notify Url Demo: http://git.io/pst4Tw
 ### Verify notify
 
 ```ruby
-# example in rails
-# The notify url MUST be set when generate payment url
-def alipay_notify
+# Example in rails,
+# both notify url MUST be set when generate payment url
+
+def alipay_web_notify
   # except :controller_name, :action_name, :host, etc.
   notify_params = params.except(*request.path_parameters.keys)
+
   if Alipay::Notify.verify?(notify_params)
     # valid notify, code your business logic.
+    render :text => 'success'
+  else
+    render :text => 'error'
+  end
+end
+
+def alipay_wap_notify
+  # except :controller_name, :action_name, :host, etc.
+  notify_params = params.except(*request.path_parameters.keys)
+
+  if Alipay::Notify::Wap.verify?(notify_params)
+    # valid notify, code your business logic.
+    # you may want to get you order id:
+    #   order_id = Hash.from_xml(params[:notify_data])['notify']['out_trade_no']
     render :text => 'success'
   else
     render :text => 'error'

--- a/lib/alipay/notify.rb
+++ b/lib/alipay/notify.rb
@@ -3,7 +3,9 @@ module Alipay
     module Wap
       def self.verify?(params)
         params = Utils.stringify_keys(params)
-        Sign::Wap.verify?(params) && Notify.verify_notify_id?(params['notify_id'])
+        notify_id = params['notify_data'].scan(/\<notify_id\>(.*)\<\/notify_id\>/).flatten.first
+
+        Sign::Wap.verify?(params) && Notify.verify_notify_id?(notify_id)
       end
     end
 
@@ -15,7 +17,7 @@ module Alipay
     private
 
     def self.verify_notify_id?(notify_id)
-      open("https://mapi.alipay.com/gateway.do?service=notify_verify&partner=#{Alipay.pid}&notify_id=#{CGI.escape notify_id.to_s}").read == 'true'
+      open("https://mapi.alipay.com/gateway.do?service=notify_verify&partner=#{Alipay.pid}&notify_id=#{CGI.escape(notify_id.to_s)}").read == 'true'
     end
   end
 end

--- a/test/alipay/notify/wap_test.rb
+++ b/test/alipay/notify/wap_test.rb
@@ -2,12 +2,13 @@ require 'test_helper'
 
 class Alipay::Notify::WapTest < Test::Unit::TestCase
   def setup
+    @notify_id = 'notify_id_test'
+
     @notify_params = {
-      :notify_id => 1234,
+      :service => 'alipay.wap.trade.create.direct',
       :v => '1.0',
       :sec_id => 'MD5',
-      :service => 'service',
-      :notify_data => '<notify><notify_id>1234</notify_id></notify>'
+      :notify_data => "<notify><notify_id>#{@notify_id}</notify_id><other_key>other_value</other_key></notify>"
     }
 
     query = [ :service, :v, :sec_id, :notify_data ].map {|key| "#{key}=#{@notify_params[key]}"}.join('&')
@@ -15,17 +16,17 @@ class Alipay::Notify::WapTest < Test::Unit::TestCase
   end
 
   def test_unsign_notify
-    FakeWeb.register_uri(:get, "https://mapi.alipay.com/gateway.do?service=notify_verify&partner=#{Alipay.pid}&notify_id=1234", :body => "true")
+    FakeWeb.register_uri(:get, "https://mapi.alipay.com/gateway.do?service=notify_verify&partner=#{Alipay.pid}&notify_id=#{@notify_id}", :body => "true")
     assert !Alipay::Notify::Wap.verify?(@notify_params)
   end
 
   def test_verify_notify_when_true
-    FakeWeb.register_uri(:get, "https://mapi.alipay.com/gateway.do?service=notify_verify&partner=#{Alipay.pid}&notify_id=1234", :body => "true")
+    FakeWeb.register_uri(:get, "https://mapi.alipay.com/gateway.do?service=notify_verify&partner=#{Alipay.pid}&notify_id=#{@notify_id}", :body => "true")
     assert Alipay::Notify::Wap.verify?(@sign_params)
   end
 
   def test_verify_notify_when_false
-    FakeWeb.register_uri(:get, "https://mapi.alipay.com/gateway.do?service=notify_verify&partner=#{Alipay.pid}&notify_id=1234", :body => "false")
+    FakeWeb.register_uri(:get, "https://mapi.alipay.com/gateway.do?service=notify_verify&partner=#{Alipay.pid}&notify_id=#{@notify_id}", :body => "false")
     assert !Alipay::Notify::Wap.verify?(@sign_params)
   end
 end


### PR DESCRIPTION
In the previous commits, we assume that the notify_id can be accessed by `params['notify_id']`.
But actually the notify params looks like:

```
  {
    :service => 'alipay.wap.trade.create.direct',
    :v => '1.0',
    :sec_id => 'MD5',
    :sign => 'signed_string'
    :notify_data => "<notify><notify_id>NOTIFY_ID</notify_id><other_key>other_value</other_key></notify>"
  }
```

So we have to extract it from `params['notify_data']`
