### PR TITLE
修复手机支付异步通知md5参数排序

### DIFF
--- a/lib/alipay/sign.rb
+++ b/lib/alipay/sign.rb
@@ -4,7 +4,7 @@ module Alipay
       params = Utils.stringify_keys(params)
       sign_type = options[:sign_type] || Alipay.sign_type
       key = options[:key] || Alipay.key
-      string = params_to_string(params)
+      string = params_to_string(params, options[:is_fixed_order])
 
       case sign_type
       when 'MD5'
@@ -32,7 +32,7 @@ NG9zpgmLCUYuLkxpLQIDAQAB
 
       sign_type = params.delete('sign_type')
       sign = params.delete('sign')
-      string = params_to_string(params)
+      string = params_to_string(params, options[:is_fixed_order])
 
       case sign_type
       when 'MD5'
@@ -47,8 +47,12 @@ NG9zpgmLCUYuLkxpLQIDAQAB
       end
     end
 
-    def self.params_to_string(params)
-      params.sort.map { |item| item.join('=') }.join('&')
+    def self.params_to_string(params, is_fixed_order)
+        if is_fixed_order
+          params.map { |item| item.join('=') }.join('&') 
+        else
+          params.sort.map { |item| item.join('=') }.join('&')
+        end
     end
   end
 end


### PR DESCRIPTION
官方文档内容：
注意:
notify_url 接受到的参数验签不要排序,只需要按照支付宝返回的参数顺序,组
装字符串,然后验签,如支付宝异步通知 POST 方式返回的参数顺序如下:
service=alipay.wap.trade.create.direct&v=1.0&sec_id=0001&notify_data=<no
tify>...</notify>

notify返回的参数不需要排序。