### PR TITLE
修复wap支付异步通知md5参数排序

### DIFF
--- a/lib/alipay/sign.rb
+++ b/lib/alipay/sign.rb
@@ -4,7 +4,7 @@ module Alipay
       params = Utils.stringify_keys(params)
       sign_type = options[:sign_type] || Alipay.sign_type
       key = options[:key] || Alipay.key
-      string = params_to_string(params)
+      string = params_to_string(params, options[:is_fixed_order])
 
       case sign_type
       when 'MD5'
@@ -32,7 +32,7 @@ NG9zpgmLCUYuLkxpLQIDAQAB
 
       sign_type = params.delete('sign_type')
       sign = params.delete('sign')
-      string = params_to_string(params)
+      string = params_to_string(params, options[:is_fixed_order])
 
       case sign_type
       when 'MD5'
@@ -47,8 +47,12 @@ NG9zpgmLCUYuLkxpLQIDAQAB
       end
     end
 
-    def self.params_to_string(params)
-      params.sort.map { |item| item.join('=') }.join('&')
+    def self.params_to_string(params, is_fixed_order)
+        if is_fixed_order
+          params.map { |item| item.join('=') }.join('&') 
+        else
+          params.sort.map { |item| item.join('=') }.join('&')
+        end
     end
   end
 end

--- a/lib/alipay/sign.rb
+++ b/lib/alipay/sign.rb
@@ -31,6 +31,7 @@ NG9zpgmLCUYuLkxpLQIDAQAB
       params = Utils.stringify_keys(params)
 
       sign_type = params.delete('sign_type')
+      sign_type = params['sec_id'] if options[:is_fixed_order]
       sign = params.delete('sign')
       string = params_to_string(params, options[:is_fixed_order])
 
@@ -48,11 +49,11 @@ NG9zpgmLCUYuLkxpLQIDAQAB
     end
 
     def self.params_to_string(params, is_fixed_order)
-        if is_fixed_order
-          params.map { |item| item.join('=') }.join('&') 
-        else
-          params.sort.map { |item| item.join('=') }.join('&')
-        end
+      if is_fixed_order
+        "service=#{params['service']}&v=#{params['v']}&sec_id=#{params['sec_id']}&notify_data=#{params['notify_data']}"
+      else
+        params.sort.map { |item| item.join('=') }.join('&')
+      end
     end
   end
 end


### PR DESCRIPTION
notify这个请求参数顺序是一个特例 

请求示例：
{"service"=>"alipay.wap.trade.create.direct", "sign"=>"7cb9c1fd26ecf1da58622b8b6e662742", "sec_id"=>"MD5", "v"=>"1.0", "notify_data"=>"<notify><payment_type>1</payment_type><subject>张三</subject><trade_no>2015060800001000410067813376</trade_no><buyer_email>mfkwfc@gmail.com</buyer_email><gmt_create>2015-06-08 14:59:35</gmt_create><notify_type>trade_status_sync</notify_type><quantity>1</quantity><out_trade_no>test_1000094494</out_trade_no><notify_time>2015-06-08 14:59:36</notify_time><seller_id>2088201962733496</seller_id><trade_status>TRADE_FINISHED</trade_status><is_total_fee_adjust>N</is_total_fee_adjust><total_fee>0.01</total_fee><gmt_payment>2015-06-08 14:59:36</gmt_payment><seller_email>pay@xxxx.com</seller_email><gmt_close>2015-06-08 14:59:36</gmt_close><price>0.01</price><buyer_id>2088102047109415</buyer_id><notify_id>5a48d316d8b97cc0383dae36fde5738c4a</notify_id><use_coupon>N</use_coupon></notify>", "alipay_id"=>"1000094494"}

文档说明：按请求原参数顺序进行md5验证。后面文档提供了一个顺序：
service=#{params['service']}&v=#{params['v']}&sec_id=#{params['sec_id']}&notify_data=#{params['notify_data']}
经测试正确顺序是文档上提供的顺序而不是文档上面写的原参数顺序不变。文档说明内容昨天我复制一份给你。现在在家。

Alipay::Notify.verify 这个方法取 
notify_id在参数里边是不存在的。需要手动解析xml后把该参数set params 然后再进行验证。
