### PR TITLE
移动端支付的问题

### DIFF
--- a/lib/alipay/sign.rb
+++ b/lib/alipay/sign.rb
@@ -4,7 +4,11 @@ module Alipay
       params = Utils.stringify_keys(params)
       sign_type = options[:sign_type] || Alipay.sign_type
       key = options[:key] || Alipay.key
-      string = params_to_string(params)
+      if sign_type == 'RSA'
+        string = params.sort.map { |i,o| "#{i}=\"#{o}\"" }.join('&')
+      else
+        string = params_to_string(params)
+      end
 
       case sign_type
       when 'MD5'

--- a/lib/alipay/sign.rb
+++ b/lib/alipay/sign.rb
@@ -4,11 +4,15 @@ module Alipay
       params = Utils.stringify_keys(params)
       sign_type = options[:sign_type] || Alipay.sign_type
       key = options[:key] || Alipay.key
-      if sign_type == 'RSA'
-        string = params.sort.map { |i,o| "#{i}=\"#{o}\"" }.join('&')
-      else
-        string = params_to_string(params)
-      end
+
+      to_string_need_quote = options[:string_need_quote] || false
+
+      string = \
+        if to_string_need_quote
+          params_to_string_with_quote(params)
+        else
+          params_to_string(params)
+        end
 
       case sign_type
       when 'MD5'
@@ -49,6 +53,10 @@ NG9zpgmLCUYuLkxpLQIDAQAB
       else
         false
       end
+    end
+
+    def self.params_to_string_with_quote(params)
+      params.sort.map { |k, v| "#{k}=\"#{v}\"" }.join('&')
     end
 
     def self.params_to_string(params)

--- a/lib/alipay/sign/rsa.rb
+++ b/lib/alipay/sign/rsa.rb
@@ -11,7 +11,7 @@ module Alipay
 
       def self.verify?(key, string, sign)
         rsa = OpenSSL::PKey::RSA.new(key)
-        rsa.verify('sha1', Base64.strict_decode64(sign), string)
+        rsa.verify('sha1', Base64.decode64(sign), string)
       end
     end
   end

--- a/lib/alipay/sign/rsa.rb
+++ b/lib/alipay/sign/rsa.rb
@@ -6,12 +6,12 @@ module Alipay
     class RSA
       def self.sign(key, string)
         rsa = OpenSSL::PKey::RSA.new(key)
-        Base64.encode64(rsa.sign('sha1', string))
+        Base64.strict_encode64(rsa.sign('sha1', string))
       end
 
       def self.verify?(key, string, sign)
         rsa = OpenSSL::PKey::RSA.new(key)
-        rsa.verify('sha1', Base64.decode64(sign), string)
+        rsa.verify('sha1', Base64.strict_decode64(sign), string)
       end
     end
   end

--- a/test/alipay/service_test.rb
+++ b/test/alipay/service_test.rb
@@ -167,7 +167,7 @@ class Alipay::ServiceTest < Minitest::Test
   end
 
   def test_mobile_security_pay_url
-    assert_equal 'https://mapi.alipay.com/gateway.do?service=mobile.securitypay.pay&_input_charset=utf-8&partner=1000000000000000&seller_id=1000000000000000&payment_type=1&out_trade_no=1&notify_url=%2Fsome_url&subject=subject&total_fee=0.01&body=test&sign_type=RSA&sign=EuHBKhLyXFBFM28s8nNM45r4gIWccPijVl8SHAmRaAC11wFNRiOfc3jEzJYJ%0A%2FADJNytARSNVSu3vXvRWhsNDHE9%2F%2BkFRckoXjjC10IApWa8bN7%2ByfHQk2w88%0AkDEVfv9Z%2F0t%2B8yHZD0Po4OBBHoEC9d%2FodPZYBElfcQvJ5vilQsc%3D%0A', Alipay::Service.mobile_security_pay_url({
+    assert_equal 'https://mapi.alipay.com/gateway.do?service=mobile.securitypay.pay&_input_charset=utf-8&partner=1000000000000000&seller_id=1000000000000000&payment_type=1&out_trade_no=1&notify_url=%2Fsome_url&subject=subject&total_fee=0.01&body=test&sign_type=RSA&sign=EuHBKhLyXFBFM28s8nNM45r4gIWccPijVl8SHAmRaAC11wFNRiOfc3jEzJYJ%2FADJNytARSNVSu3vXvRWhsNDHE9%2F%2BkFRckoXjjC10IApWa8bN7%2ByfHQk2w88kDEVfv9Z%2F0t%2B8yHZD0Po4OBBHoEC9d%2FodPZYBElfcQvJ5vilQsc%3D', Alipay::Service.mobile_security_pay_url({
       out_trade_no: '1',
       notify_url: '/some_url',
       subject: 'subject',

--- a/test/alipay/sign/rsa_test.rb
+++ b/test/alipay/sign/rsa_test.rb
@@ -7,7 +7,7 @@ class Alipay::Sign::RSATest < Minitest::Test
   end
 
   def test_sign
-    assert_equal @sign, Alipay::Sign::RSA.sign(TEST_RSA_PRIVATE_KEY, @string)
+    assert_equal @sign.gsub("\n", ''), Alipay::Sign::RSA.sign(TEST_RSA_PRIVATE_KEY, @string)
   end
 
   def test_verify


### PR DESCRIPTION
最近做了移动端支付，这里有2个修改
1，计算string时需要包括双引号，所以加入了一个可以自定义输入是否包括双引号的选项
![dri71g557mno m n sj6m6x](https://cloud.githubusercontent.com/assets/3863/8742883/34ca0d8a-2c9c-11e5-868e-92c341b658c1.jpg)

2，计算base64的时候，应去掉多余的"\n"