### PR TITLE
Revert "Add deprecated message to changelog"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,6 @@
 ## v0.9.0 (2015-10-15)
 
 - Add `Alipay::Service.create_direct_pay_by_user_wap_url` method, thanks @serco-chen #52
-- Deprecated Wap::Service module.
 
 ## v0.8.0 (2015-07-20)
 


### PR DESCRIPTION
花了一点时间把 KnewOne 的 alipay 升级到最新版（之前一直在用 0.3.0 因为我做了大量不兼容上游的魔改...）

情况是这样的：

- 支付宝的后台进行了大的改版，包括套餐的种类也有很大的变动
- `WAP module` 的接口应该是属于 `无线快捷套餐V2` 的范畴，但是这个套餐不出现在产品大全里（似乎是支付宝的大客户专员直接和我们对接的，包括我们的签约订单列表里有很多产品大全里没有的项目）
- 当我们包含了 `无线快捷套餐V2` 时，再在产品大全里选择重叠的产品，如 `移动支付` ，则会提示 `您已签约 无线快捷套餐V2 ，无法签约本产品，详情请咨询客服` 
- 这个服务主要提供的是，在移动端浏览器（如 `Safari` ）内提供一个现代一些，并且做了适配的支付体验，普通的支付接口并没有做移动端的适配
- 这套接口没有死！
- 文档？很抱歉，我当初开发的时候确实有文档可下，可惜我今天找了一个多小时都没找到哪里有文档... 签约商品里还有帮助中心，都没有（他说将来会找到的~~）...
- 风险探测接口，也是真实存在，而且必须配套服用的，否则有一个500元的额度限制，这个倒是能找到 [文档](https://openhome.alipay.com/doc/viewApiDoc.htm?name=alipay.security.risk.detect&version=1.0&subVersion=1.0&packageCode=SECURITY) 但文档标注的返回结构是错误的，生产环境测试这个接口返回的响应体为空字符串（200状态码，500元的限制被解除，可以说明请求成功了），另外当初开发这个接口调用的时候，支付宝会安排工程师检查接口使用方法是否标准