### PR TITLE
风险探测接口

### DIFF
--- a/README.md
+++ b/README.md
@@ -538,6 +538,52 @@ Alipay::Wap::Service.auth_and_execute_url(request_token: token)
 | --- | ----------- | ----------- |
 | request_token | required | Get from trade_create_direct_token |
 
+### 风险探测服务接口
+
+#### Name
+
+```ruby
+alipay.security.risk.detect
+```
+
+#### Definition
+
+```ruby
+Alipay::Wap::Service.security_risk_detect({ARGUMENTS}, {OPTIONS})
+```
+
+#### Example
+
+```ruby
+Alipay::Wap::Service.security_risk_detect({
+  order_no: '1',
+  order_credate_time: '1970-01-01 00:00:00',
+  order_category: 'TestCase^AlipayGem^Ruby',
+  order_item_name: 'item',
+  order_amount: '0.01',
+  buyer_account_no: '2088123123',
+  buyer_bind_mobile: '13600000000',
+  buyer_reg_date: '1970-01-01 00:00:00',
+  terminal_type: 'WAP'
+}, {
+  sign_type: 'RSA',
+  key: RSA_PRIVATE_KEY
+})
+```
+#### ARGUMENTS
+
+| Key | Requirement | Description |
+| --- | ----------- | ----------- |
+| order_no | optional | Order id in your application. |
+| order_credate_time | optional | Order created time. |
+| order_category | optional | Categories of Order's items. using `^` as splitter. |
+| order_item_name | optional | Order subject. |
+| order_amount | optional | Order item's price. |
+| buyer_account_no | optional | User id in your application. |
+| buyer_reg_date | optional | User created time. |
+| buyer_bind_mobile | optional | User mobile phone. |
+| terminal_type | optional | The terminal type which user are using to request the payment, can be `MOBILE` for App, `WAP` for mobile, `WEB` for PC. |
+
 ### 验证通知
 
 #### Name

--- a/lib/alipay/wap/service.rb
+++ b/lib/alipay/wap/service.rb
@@ -30,7 +30,6 @@ module Alipay
       end
 
       AUTH_AND_EXECUTE_REQUIRED_PARAMS = %w( request_token )
-
       def self.auth_and_execute_url(params, options = {})
         params = Utils.stringify_keys(params)
         Alipay::Service.check_required_params(params, AUTH_AND_EXECUTE_REQUIRED_PARAMS)
@@ -46,6 +45,22 @@ module Alipay
         }.merge(params)
 
         request_uri(params, options).to_s
+      end
+
+      def self.security_risk_detect(params, options)
+        params = Utils.stringify_keys(params)
+
+        params = {
+          'service' => 'alipay.security.risk.detect',
+          '_input_charset' => 'utf-8',
+          'partner' => options[:pid] || Alipay.pid,
+          'timestamp' => Time.now.strftime('%Y-%m-%d %H:%M:%S'),
+          'scene_code' => 'PAYMENT'
+        }.merge(params)
+
+        sign_params(params, options)
+
+        Net::HTTP.post_form(URI(GATEWAY_URL), params)
       end
 
       def self.request_uri(params, options = {})

--- a/test/alipay/wap/service_test.rb
+++ b/test/alipay/wap/service_test.rb
@@ -37,4 +37,31 @@ class Alipay::Wap::ServiceTest < Minitest::Test
   def test_auth_and_execute_url
     assert_equal 'https://wappaygw.alipay.com/service/rest.htm?service=alipay.wap.auth.authAndExecute&req_data=%3Cauth_and_execute_req%3E%3Crequest_token%3Etoken_test%3C%2Frequest_token%3E%3C%2Fauth_and_execute_req%3E&partner=1000000000000000&format=xml&v=2.0&sec_id=MD5&sign=3efe60d4a9b7960ba599da6764c959df', Alipay::Wap::Service.auth_and_execute_url(request_token: 'token_test')
   end
+
+  def test_security_risk_detect
+    FakeWeb.register_uri(
+      :post,
+      %r|https://wappaygw\.alipay\.com/service/rest\.htm.*|,
+      body: ''
+    )
+
+    params = {
+      order_no: '1',
+      order_credate_time: Time.now.strftime('%Y-%m-%d %H:%M:%S'),
+      order_category: 'TestCase^AlipayGem^Ruby',
+      order_item_name: 'item',
+      order_amount: '0.01',
+      buyer_account_no: '2088123123',
+      buyer_bind_mobile: '13600000000',
+      buyer_reg_date: '1970-01-01 00:00:00',
+      terminal_type: 'WAP'
+    }
+
+    options = {
+      sign_type: 'RSA',
+      key: TEST_RSA_PRIVATE_KEY
+    }
+
+    assert_equal '', Alipay::Wap::Service.security_risk_detect(params, options).body
+  end
 end


### PR DESCRIPTION
我好久之前提过这个接口，手机环境下移动支付若不调用这个接口，则会有500元的单笔限额。

这个接口只需要调用，并不需要关心返回值。

需要注意的是，这个接口是由支付宝的大客户专员要求对接，在商户后台是找不到这个文档资料的！然而我接入这个代码大约有两年的时间了，文档已经遗失。

[支付宝开放平台](https://openhome.alipay.com/doc/viewApiDoc.htm?name=alipay.security.risk.detect&version=1.0&subVersion=1.0&packageCode=SECURITY) 的接口说明和实际情况有较大出入，具体体现为，接口返回响应体为空，状态码为200，接口字段虽然都标记为可选，但哪些必填是由支付宝的工程师负责检查和提示的。此外，提交的数据多寡并不影响返回值，行不行支付宝的对接工程师说了算！

PS：这个接口会暴露大量用户敏感信息，个人非常反感，但没有办法，不调用就有限额