### PR TITLE
public_key configurable

### DIFF
--- a/lib/alipay.rb
+++ b/lib/alipay.rb
@@ -19,7 +19,7 @@ module Alipay
   @sign_type = 'MD5'
 
   class << self
-    attr_accessor :pid, :key, :sign_type, :debug_mode
+    attr_accessor :pid, :key, :sign_type, :debug_mode, :public_key
 
     def debug_mode?
       !!@debug_mode

--- a/lib/alipay/sign.rb
+++ b/lib/alipay/sign.rb
@@ -39,7 +39,7 @@ NG9zpgmLCUYuLkxpLQIDAQAB
         key = options[:key] || Alipay.key
         MD5.verify?(key, string, sign)
       when 'RSA'
-        RSA.verify?(ALIPAY_RSA_PUBLIC_KEY, string, sign)
+        RSA.verify?(Alipay.public_key || ALIPAY_RSA_PUBLIC_KEY, string, sign)
       when 'DSA'
         DSA.verify?(string, sign)
       else


### PR DESCRIPTION
Found RSA sign verify fail under production environment, we have a alipay public key, which is different with the origin ALIPAY_RSA_PUBLIC_KEY.
