### PR TITLE
Bug fix for the formatting of the public key

### DIFF
--- a/doc/rsa_key_cn.md
+++ b/doc/rsa_key_cn.md
@@ -58,11 +58,7 @@ Base64.strict_encode64(@app_key.sign('sha256', "a=123"))
 
 ```ruby
 pub_key = "MIIBI...HpwIDAQAB"
-pub_key.tap do |key|
-  key.scan(/.{64}/).join("\n")
-  key.insert(0, "-----BEGIN PUBLIC KEY-----\n")
-  key.insert(-1, "\n-----END PUBLIC KEY-----\n")
-end
+pub_key.scan(/.{64}|.+$/).join("\n").insert(0, "-----BEGIN PUBLIC KEY-----\n").insert(-1, "\n-----END PUBLIC KEY-----\n")
 # => "-----BEGIN PUBLIC KEY-----\nMIIBI...\n-----END PUBLIC KEY-----\n"
 ```
 

--- a/doc/rsa_key_en.md
+++ b/doc/rsa_key_en.md
@@ -71,11 +71,7 @@ formatting back, run the following script.
 
 ```ruby
 pub_key = "MIIBI...HpwIDAQAB"
-pub_key.tap do |key|
-  key.scan(/.{64}/).join("\n")
-  key.insert(0, "-----BEGIN PUBLIC KEY-----\n")
-  key.insert(-1, "\n-----END PUBLIC KEY-----\n")
-end
+pub_key.scan(/.{64}|.+$/).join("\n").insert(0, "-----BEGIN PUBLIC KEY-----\n").insert(-1, "\n-----END PUBLIC KEY-----\n")
 # => "-----BEGIN PUBLIC KEY-----\nMIIBI...\n-----END PUBLIC KEY-----\n"
 ```
 


### PR DESCRIPTION
1. A wrong regular expression was used, it ignored the last few characters whose length is less than 64.
2. #scan #join won't update the string itself, #insert wasn't applied on the correct string.